### PR TITLE
Align post service with search and delete endpoints

### DIFF
--- a/frontend/src/pages/__tests__/HomePage.createPost.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.createPost.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { routes } from '@/routes';
 import { AuthProvider } from '@/context/AuthContext';
 import { ToastProvider } from '@/context/ToastContext';
 import * as postServiceModule from '@/services/postService';
+import { authService } from '@/services/authService';
+import { categoryService } from '@/services/categoryService';
 import type { PostSummary } from '@/types/post';
 
 function renderWithProviders(initialEntries: string[]) {
@@ -13,21 +15,48 @@ function renderWithProviders(initialEntries: string[]) {
     initialEntries,
   });
 
+  const renderResult = render(
+    <ToastProvider>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </ToastProvider>,
+  );
+
   return {
     router,
-    renderResult: (
-      <ToastProvider>
-        <AuthProvider>
-          <RouterProvider router={router} />
-        </AuthProvider>
-      </ToastProvider>
-    ),
+    renderResult,
   };
 }
 
 describe('HomePage create post flow', () => {
   it('opens the create post modal, validates required fields, and calls createPost on submit', async () => {
     const user = userEvent.setup();
+
+    vi.spyOn(authService, 'getSession').mockReturnValue({
+      user: {
+        email: 'john@example.com',
+        name: 'John Doe',
+        role: 'USER',
+      },
+      isAuthenticated: true,
+    });
+
+    vi.spyOn(postServiceModule.postService, 'getPosts').mockResolvedValue({
+      content: [],
+      totalElements: 0,
+      totalPages: 0,
+      size: 10,
+      number: 0,
+    });
+
+    vi.spyOn(categoryService, 'getCategories').mockResolvedValue([
+      {
+        id: 1,
+        name: 'NEWS',
+        description: null,
+      },
+    ]);
 
     const createPostSpy = vi
       .spyOn(postServiceModule.postService, 'createPost')
@@ -44,6 +73,23 @@ describe('HomePage create post flow', () => {
         commentCount: 0,
       } satisfies PostSummary);
 
+    vi.spyOn(postServiceModule.postService, 'getPostById').mockResolvedValue({
+      id: 123,
+      title: 'New title',
+      content: 'New content',
+      categoryName: 'NEWS',
+      categoryId: 1,
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      commentCount: 0,
+    } satisfies PostSummary);
+
+    vi.spyOn(postServiceModule.postService, 'getComments').mockResolvedValue(
+      [],
+    );
+
     const { renderResult } = renderWithProviders(['/']);
     expect(renderResult).toBeTruthy();
 
@@ -53,14 +99,12 @@ describe('HomePage create post flow', () => {
 
     await user.click(createButton);
 
-    const dialogTitle = await screen.findByRole('heading', {
+    await screen.findByRole('heading', {
       name: /create new post/i,
     });
-    expect(dialogTitle).toBeInTheDocument();
-
-    const submitButton = screen.getByRole('button', {
+    const submitButton = screen.getAllByRole('button', {
       name: /^create post$/i,
-    });
+    })[1];
     await user.click(submitButton);
 
     expect(await screen.findByText(/title is required/i)).toBeInTheDocument();
@@ -68,12 +112,21 @@ describe('HomePage create post flow', () => {
     expect(screen.getByText(/content is required/i)).toBeInTheDocument();
 
     const titleInput = screen.getByLabelText(/post title/i);
-    const categorySelect = screen.getByLabelText(/category/i);
     const contentTextarea = screen.getByLabelText(/content/i);
 
     await user.type(titleInput, 'New title');
-    await user.selectOptions(categorySelect, 'NEWS');
     await user.type(contentTextarea, 'New content');
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /select/i,
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /news/i,
+      }),
+    );
 
     await user.click(submitButton);
 

--- a/frontend/src/services/__tests__/postService.test.ts
+++ b/frontend/src/services/__tests__/postService.test.ts
@@ -4,6 +4,86 @@ import { postService } from '@/services/postService';
 import { server } from '@/test/server';
 
 describe('postService', () => {
+  it('fetches a paginated list of posts', async () => {
+    server.use(
+      http.get('/api/posts', () =>
+        HttpResponse.json({
+          content: [
+            {
+              id: 1,
+              title: 'First',
+              content: 'First content',
+              categoryName: 'General',
+              categoryId: 1,
+              authorName: 'Author',
+              authorEmail: 'author@example.com',
+              createdAt: '2024-01-01T00:00:00Z',
+              updatedAt: '2024-01-01T00:00:00Z',
+              commentCount: 0,
+            },
+          ],
+          totalElements: 1,
+          totalPages: 1,
+          size: 10,
+          number: 0,
+        }),
+      ),
+    );
+
+    const page = await postService.getPosts();
+
+    expect(page.content).toHaveLength(1);
+    expect(page.content[0]?.title).toBe('First');
+  });
+
+  it('delegates to the search endpoint when filters are provided', async () => {
+    const handler = http.get('/api/posts/search', ({ request }) => {
+      const url = new URL(request.url);
+      const keyword = url.searchParams.get('keyword');
+
+      if (keyword !== 'spring') {
+        return HttpResponse.json(
+          {
+            content: [],
+            totalElements: 0,
+            totalPages: 0,
+            size: 10,
+            number: 0,
+          },
+          { status: 200 },
+        );
+      }
+
+      return HttpResponse.json({
+        content: [
+          {
+            id: 2,
+            title: 'Spring Tips',
+            content: 'Content about Spring',
+            categoryName: 'Engineering',
+            categoryId: 2,
+            authorName: 'Dev',
+            authorEmail: 'dev@example.com',
+            createdAt: '2024-01-02T00:00:00Z',
+            updatedAt: '2024-01-02T00:00:00Z',
+            commentCount: 0,
+          },
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        size: 10,
+        number: 0,
+      });
+    });
+
+    server.use(handler);
+
+    const page = await postService.getPosts({ keyword: 'spring' });
+
+    expect(page.content).toHaveLength(1);
+    expect(page.content[0]?.title).toBe('Spring Tips');
+  });
+
   it('fetches a post by id', async () => {
     server.use(
       http.get('/api/posts/1', () =>
@@ -46,5 +126,20 @@ describe('postService', () => {
 
     expect(comments).toHaveLength(1);
     expect(comments[0]?.content).toBe('Nice post');
+  });
+
+  it('deletes a post', async () => {
+    const deleteSpy = vi.fn();
+
+    server.use(
+      http.delete('/api/posts/3', () => {
+        deleteSpy();
+        return HttpResponse.json(null, { status: 204 });
+      }),
+    );
+
+    await postService.deletePost(3);
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/services/postService.ts
+++ b/frontend/src/services/postService.ts
@@ -7,6 +7,15 @@ const BASE_PATH = '/posts';
 export interface GetPostsParams {
   page?: number;
   size?: number;
+  /**
+   * Optional filters; when any are present we delegate
+   * to the backend search endpoint:
+   *   GET /api/posts/search
+   */
+  categoryId?: number;
+  keyword?: string;
+  startDate?: string;
+  endDate?: string;
 }
 
 export interface CreatePostRequest {
@@ -20,13 +29,37 @@ export type UpdatePostRequest = CreatePostRequest;
 export const postService = {
   /**
    * Fetch a paginated list of posts from the backend.
-   * Mirrors the Spring endpoint:
+   * Mirrors the Spring endpoints:
    *   GET /api/posts?page=0&size=10
+   *   GET /api/posts/search?... (when filters are provided)
    */
   async getPosts(params: GetPostsParams = {}): Promise<PaginatedPosts> {
-    const { page = 0, size = 10 } = params;
-    const { data } = await apiClient.get<PaginatedPosts>(BASE_PATH, {
-      params: { page, size },
+    const {
+      page = 0,
+      size = 10,
+      categoryId,
+      keyword,
+      startDate,
+      endDate,
+    } = params;
+
+    const hasSearchFilters =
+      categoryId !== undefined ||
+      Boolean(keyword) ||
+      Boolean(startDate) ||
+      Boolean(endDate);
+
+    const path = hasSearchFilters ? `${BASE_PATH}/search` : BASE_PATH;
+
+    const { data } = await apiClient.get<PaginatedPosts>(path, {
+      params: {
+        page,
+        size,
+        categoryId,
+        keyword,
+        startDate,
+        endDate,
+      },
     });
     return data;
   },
@@ -79,5 +112,14 @@ export const postService = {
       payload,
     );
     return data;
+  },
+
+  /**
+   * Delete a post.
+   * Mirrors:
+   *   DELETE /api/posts/{id}
+   */
+  async deletePost(id: number): Promise<void> {
+    await apiClient.delete(`${BASE_PATH}/${id.toString()}`);
   },
 };


### PR DESCRIPTION
## What does this PR do?

- Aligns frontend post service with backend endpoints by:
- Adding support for GET /api/posts/search via extended getPosts filters (categoryId, keyword, startDate, endDate).
- Adding deletePost wired to DELETE /api/posts/{id}.
- Adds coverage for new service behavior:
- 
## Related Issue
Closes #

## Type of Change
- [x] New feature (backend/frontend/DevOps)
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD improvement

## Testing
- [x] Tested locally with `docker compose up`
- [ ] All CI checks pass
- [x] No console errors or warnings

## Screenshots (if UI changes)
N/A

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded secrets or credentials
- [x] Added/updated tests if needed
- [ ] Updated documentation if needed
- [x] Ready for review

## DevOps Notes (if applicable)
N/A
