### PR TITLE
feat(US-09): enable authenticated users to add comments

### DIFF
--- a/frontend/src/components/features/posts/PostDetailView.tsx
+++ b/frontend/src/components/features/posts/PostDetailView.tsx
@@ -81,11 +81,11 @@ export function PostDetailView({
               <Text as="h1" variant="headingAuth" className="text-primary">
                 {title}
               </Text>
-              <Chip variant={chipVariant}>{categoryLabel}</Chip>
             </div>
 
             {(canEdit && onEdit) || (canDelete && onDelete) ? (
               <div className="flex items-center gap-2">
+                <Chip variant={chipVariant}>{categoryLabel}</Chip>
                 {canEdit && onEdit ? (
                   <button
                     type="button"

--- a/frontend/src/hooks/usePostComments.ts
+++ b/frontend/src/hooks/usePostComments.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { postService } from '@/services/postService';
+import type { Comment } from '@/types/comment';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/useToast';
+
+export interface UsePostCommentsResult {
+  comments: Comment[] | null;
+  commentDraft: string;
+  isSubmitting: boolean;
+  setCommentDraft: (next: string) => void;
+  addComment: () => Promise<void>;
+}
+
+export function usePostComments(
+  postId: number | null,
+  initialComments: Comment[] | null,
+  isInitialLoading: boolean,
+): UsePostCommentsResult {
+  const { user, isAuthenticated } = useAuth();
+  const toast = useToast();
+
+  const [comments, setComments] = useState<Comment[] | null>(initialComments);
+  const [commentDraft, setCommentDraft] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isInitialLoading && comments === null && initialComments) {
+      setComments(initialComments);
+    }
+  }, [comments, initialComments, isInitialLoading]);
+
+  const addComment = async (): Promise<void> => {
+    if (!postId) return;
+
+    if (!isAuthenticated || !user) {
+      toast.error({
+        title: 'Login required',
+        description: 'Please log in to add a comment.',
+      });
+      return;
+    }
+
+    const trimmed = commentDraft.trim();
+    if (!trimmed) {
+      toast.error({
+        title: 'Comment required',
+        description: 'Please enter a comment before submitting.',
+      });
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const next = await postService.createComment(postId, {
+        content: trimmed,
+      });
+      setComments((prev) => {
+        if (!prev) return [next];
+        return [...prev, next];
+      });
+      setCommentDraft('');
+    } catch {
+      toast.error({
+        title: 'Failed to add comment',
+        description: 'Something went wrong while adding your comment.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    comments,
+    commentDraft,
+    isSubmitting,
+    setCommentDraft,
+    addComment,
+  };
+}


### PR DESCRIPTION
## What does this PR do?
Implements comment functionality for authenticated users on post detail pages:
- Users can add comments to posts
- Comment form with text editor and submit button
- Real-time comment display after submission
- Comments include author name and timestamp
- Only authenticated users can see and interact with comment features
- 
## Related Issue
Closes #60 

## Type of Change
- [x] New feature (backend/frontend/DevOps)
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD improvement

## Testing
- [x] Tested locally with `docker compose up`
- [ ] All CI checks pass
- [x] No console errors or warnings

## Screenshots (if UI changes)
N/A

## Checklist
- [x] Code follows project conventions
- [x] No hardcoded secrets or credentials
- [x] Added/updated tests if needed
- [ ] Updated documentation if needed
- [x] Ready for review

## DevOps Notes (if applicable)
N/A
